### PR TITLE
support integers as arguments to {% use_macro %}

### DIFF
--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -229,7 +229,7 @@ def do_usemacro(parser, token):
     kwarg_regex = (
         r'^([A-Za-z_][\w_]*)=(".*"|{0}.*{0}|[A-Za-z_][\w_]*)$'.format(
             "'"))
-    arg_regex = r'^([A-Za-z_][\w_]*|".*"|{0}.*{0})$'.format(
+    arg_regex = r'^([A-Za-z_][\w_]*|".*"|{0}.*{0}|(\d+))$'.format(
         "'")
     for value in values:
         # must check against the kwarg regex first


### PR DESCRIPTION
The `arg_regex` variable in the `do_usemacro` function currently makes it impossible to pass constant numbers in a `{% use_macro %}` call (eg. `{% use_macro mymacro 1 2 3 %}`). I made a tiny patch to support integers; I thought about doing floating points and bools also but I wasn't quite sure I was doing the right thing, and if it were up to me I would eliminate that regex entirely and just try to create the `template.Variable` from anything that doesn't match the `kwarg_regex`, and let Django decide if what's passed in is valid or not.