### PR TITLE
typo, missing macro name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When you have a section of your template you want to repeat, but don't want to h
 Then when you want to use the macro, simply do:
 
 ```
-{% use_macro "foo" "bar" kwarg="nondefault value" %}
+{% use_macro some_macro_name "foo" "bar" kwarg="nondefault value" %}
 ```
 
 which renders to:


### PR DESCRIPTION
Neat package, thanks for authoring.

I think this is just a minor oversight in the docs.