### PR TITLE
Django 1.8 fix: AttributeError: 'Template' object has no attribute 'nodelist'

### DIFF
--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -158,7 +158,13 @@ def do_loadmacros(parser, token):
             "Malformed argument to the {0} template tag.".format(tag_name) +
             " Argument must be in quotes.")
     t = get_template(filename)
-    macros = t.nodelist.get_nodes_by_type(DefineMacroNode)
+    try:
+        # Works for Django 1.8
+        nodelist = t.template.nodelist
+    except AttributeError:
+        # Works for Django < 1.8
+        nodelist = t.nodelist
+    macros = nodelist.get_nodes_by_type(DefineMacroNode)
     # make sure the _macros attribute dictionary is instantiated
     # on the parser, then add the macros to it.
     _setup_macros_dict(parser)


### PR DESCRIPTION
The get_template call returns something different for Django 1.8:
- In Django 1.7 it returns a django.template.Template.
- In Django 1.8 it returns a django.template.backends.django.Template.
