### PR TITLE
Extended syntax for macro_block and a few other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ default arg1 default arg2 Default baz
 Sometimes you might want to include data that is rendered by the template engine, or longer data containing a lot of html in a macro. For this, the syntax of plugging arguments directly into the tag doesn't really work, so instead of `{% use_macro some_macro_name "arg" kwarg_name="value" %}`, use the syntax below:
 
 ```
-{% macro_block some_macro_name %}
+{% macro_block some_macro_name "arg1" kwname1="value1" %}
     {% macro_arg %}
-        arg
+        arg2
     {% endmacro_arg %}
     
-    {% macro_kwarg kwarg_name %}
-        value
+    {% macro_kwarg kwname2 %}
+        value2
     {% endmacro_kwarg %}
 {% endmacro_block %}
 ```

--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -198,9 +198,13 @@ class UseMacroNode(template.Node):
             if name in self.kwargs:
                 context[name] = self.kwargs[name].resolve(context)
             else:
-                # default template variable is resolved when
-                # the macro definition is rendered.
-                context[name] = default
+                if isinstance(default, template.Variable):
+                    # variables must be resolved explicitly,
+                    # because otherwise if macro's loaded from
+                    # a separate file things will break
+                    context[name] = default.resolve(context)
+                else:
+                    context[name] = default
 
         # return the nodelist rendered in the adjusted context
         return self.macro.nodelist.render(context)

--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -14,28 +14,29 @@ macros within django templates.
 from re import match as regex_match
 from django import template
 from django.template.loader import get_template
- 
+
 register = template.Library()
- 
- 
+
+
 def _setup_macros_dict(parser):
     """ initiates the _macros attribute on the parser
     object, allowing for storage of the macros in the parser.
     """
-    ## Each macro is stored in a new attribute
-    ## of the 'parser' class. That way we can access it later
-    ## in the template when processing 'use_macro' tags.
+    # Each macro is stored in a new attribute
+    # of the 'parser' class. That way we can access it later
+    # in the template when processing 'use_macro' tags.
     try:
         # don't overwrite the attribute if it already exists
         parser._macros
     except AttributeError:
         parser._macros = {}
- 
- 
+
+
 class DefineMacroNode(template.Node):
     """ The node object for the tag which
     defines a macro.
     """
+
     def __init__(self, name, nodelist, args, kwargs):
         # the values in the kwargs dictionary are by
         # assumption instances of template.Variable.
@@ -43,19 +44,19 @@ class DefineMacroNode(template.Node):
         self.nodelist = nodelist
         self.args = args
         self.kwargs = kwargs
- 
+
     def render(self, context):
         # convert template variable defaults into resolved
         # variables.
         #
-        ## recall all defaults are template variables
-        self.kwargs = {k:v.resolve(context)
-            for k, v in self.kwargs.items()}
+        # recall all defaults are template variables
+        self.kwargs = {k: v.resolve(context)
+                       for k, v in self.kwargs.items()}
 
-        ## empty string - {% macro %} tag has no output
+        # empty string - {% macro %} tag has no output
         return ''
- 
- 
+
+
 @register.tag(name="macro")
 def do_macro(parser, token):
     """ the function taking the parsed tag and returning
@@ -67,27 +68,26 @@ def do_macro(parser, token):
     except IndexError:
         raise template.TemplateSyntaxError(
             "'{0}' tag requires at least one argument (macro name)".format(
-            token.contents.split()[0]))
-    
+                token.contents.split()[0]))
+
     # use regex's to parse the arguments into arg
     # and kwarg definitions
 
     # the regex for identifying python variable names is:
-    ##  r'^[A-Za-z_][\w_]*$'
+    #  r'^[A-Za-z_][\w_]*$'
 
     # args must be proper python variable names
-    ## we'll want to capture it from the regex also.
+    # we'll want to capture it from the regex also.
     arg_regex = r'^([A-Za-z_][\w_]*)$'
 
     # kwargs must be proper variable names with a
     # default value, name="value", or name=value if
     # value is a template variable (potentially with
     # filters).
-    ## we'll want to capture the name and value from
-    ## the regex as well.
+    # we'll want to capture the name and value from
+    # the regex as well.
     kwarg_regex = (
-        r'^([A-Za-z_][\w_]*)=(".*"|{0}.*{0}|[A-Za-z_][\w_]*)$'.format(
-            "'"))
+        r'^([A-Za-z_][\w_]*)=(".*"|{0}.*{0}|[A-Za-z_][\w_]*)$'.format("'"))
     # leave further validation to the template variable class
 
     args = []
@@ -108,26 +108,27 @@ def do_macro(parser, token):
                 raise template.TemplateSyntaxError(
                     "Malformed arguments to the {0} tag.".format(
                         tag_name))
-    
+
     # parse to the endmacro tag and get the contents
-    nodelist = parser.parse(('endmacro', ))
+    nodelist = parser.parse(('endmacro',))
     parser.delete_first_token()
- 
+
     # store macro in parser._macros, creating attribute
     # if necessary
     _setup_macros_dict(parser)
     parser._macros[macro_name] = DefineMacroNode(
         macro_name, nodelist, args, kwargs)
     return parser._macros[macro_name]
- 
- 
+
+
 class LoadMacrosNode(template.Node):
     """ The template tag node for loading macros from
     an external sheet.
     """
+
     def __init__(self, macros):
         self.macros = macros
-        
+
     def render(self, context):
         # render all macro definitions in the current
         # context to set their template variable default
@@ -137,8 +138,8 @@ class LoadMacrosNode(template.Node):
 
         ## empty string - {% loadmacros %} tag does no output
         return ''
- 
- 
+
+
 @register.tag(name="loadmacros")
 def do_loadmacros(parser, token):
     """ The function taking a parsed tag and returning
@@ -150,13 +151,14 @@ def do_loadmacros(parser, token):
     except ValueError:
         raise template.TemplateSyntaxError(
             "'{0}' tag requires exactly one argument (filename)".format(
-            token.contents.split()[0]))
+                token.contents.split()[0]))
     if filename[0] in ('"', "'") and filename[-1] == filename[0]:
         filename = filename[1:-1]
     else:
         raise template.TemplateSyntaxError(
-            "Malformed argument to the {0} template tag.".format(tag_name) +
-            " Argument must be in quotes.")
+            "Malformed argument to the {0} template tag."
+            " Argument must be in quotes.".format(tag_name)
+        )
     t = get_template(filename)
     macros = t.nodelist.get_nodes_by_type(DefineMacroNode)
     # make sure the _macros attribute dictionary is instantiated
@@ -167,20 +169,20 @@ def do_loadmacros(parser, token):
     # pass macros to LoadMacrosNode so that it can
     # resolve the macros template variable kwargs on render
     return LoadMacrosNode(macros)
- 
- 
+
+
 class UseMacroNode(template.Node):
     """ Template tag Node object for the tag which
     uses a macro.
     """
- 
+
     def __init__(self, macro, args, kwargs):
         # all the values kwargs and the items in args
         # are by assumption template.Variable instances.
         self.macro = macro
         self.args = args
         self.kwargs = kwargs
- 
+
     def render(self, context):
 
         # add all of the use_macros args into context
@@ -248,7 +250,7 @@ def parse_macro_params(token):
 
     return tag_name, macro_name, args, kwargs
 
- 
+
 @register.tag(name="use_macro")
 def do_usemacro(parser, token):
     """ The function taking a parsed template tag
@@ -259,7 +261,8 @@ def do_usemacro(parser, token):
         macro = parser._macros[macro_name]
     except (AttributeError, KeyError):
         raise template.TemplateSyntaxError(
-            "Macro '{0}' is not defined previously to the {1} tag".format(macro_name, tag_name))
+            "Macro '{0}' is not defined previously to the {1} tag".format(
+                macro_name, tag_name))
     macro.parser = parser
     return UseMacroNode(macro, args, kwargs)
 
@@ -268,6 +271,7 @@ class MacroBlockNode(UseMacroNode):
     """ Template node object for the extended
     syntax macro useage.
     """
+
     def __init__(self, macro, nodelist, args, kwargs):
         self.nodelist = nodelist
         super(MacroBlockNode, self).__init__(macro, args, kwargs)
@@ -287,15 +291,15 @@ def do_macro_block(parser, token):
         macro = parser._macros[macro_name]
     except (AttributeError, KeyError):
         raise template.TemplateSyntaxError(
-            "Macro '{0}' is not defined ".format(macro_name) + 
+            "Macro '{0}' is not defined ".format(macro_name) +
             "previously to the {0} tag".format(tag_name))
     # get the arg and kwarg nodes from the nodelist
-    nodelist = parser.parse(('endmacro_block', ))
+    nodelist = parser.parse(('endmacro_block',))
     parser.delete_first_token()
 
     # Loop through nodes, sorting into args/kwargs
-    ## (we could do this more semantically, but we loop
-    ## only once like this as an optimization).
+    # (we could do this more semantically, but we loop
+    # only once like this as an optimization).
     for node in nodelist:
         if isinstance(node, MacroArgNode):
             args.append(node)
@@ -303,7 +307,7 @@ def do_macro_block(parser, token):
             if node.keyword in macro.kwargs:
                 # check that the keyword is defined as an argument for
                 # the macro.
-                if not node.keyword in kwargs:
+                if node.keyword not in kwargs:
                     # add the keyword argument to the dict
                     # if it's not in there
                     kwargs[node.keyword] = node
@@ -312,27 +316,29 @@ def do_macro_block(parser, token):
                     # keyword is already in the dict (thus a keyword
                     # argument was passed twice.
                     raise template.TemplateSyntaxError(
-                        "{0} template tag was supplied ".format(tag_name) +
-                        "the same keyword argument multiple times.")
+                        "{0} template tag was supplied "
+                        "the same keyword argument multiple times.".format(
+                            tag_name))
             else:
                 raise template.TemplateSyntaxError(
-                    "{0} template tag was supplied with a ".format(tag_name) +
-                    "keyword argument not defined by the {0} macro.".format(macro_name))
-## removed this check because you'll want to allow whitespace to format the tags in your
-## templates...
-##        else:
-##            raise template.TemplateSyntaxError(
-##                "{0} template tag received an argument that ".format(tag_name) + 
-##                "is neither a arg or a kwarg tag. Make sure there's "
-##                "text or template tags directly descending from the {0} tag.".format(tag_name))
+                    "{0} template tag was supplied with a "
+                    "keyword argument not defined by the {1} macro.".format(
+                        tag_name, macro_name))
+        elif not isinstance(node, template.TextNode) or node.s.strip() != "":
+            # whitespace is allowed, anything else is not
+            raise template.TemplateSyntaxError(
+                "{0} template tag received an argument that "
+                "is neither a arg or a kwarg tag. Make sure there's "
+                "text or template tags directly descending "
+                "from the {0} tag.".format(tag_name))
 
     # check that there aren't more arg tags than args
     # in the macro.
     if len(args) > len(macro.args):
         raise template.TemplateSyntaxError(
-            "{0} template tag was supplied too many ".format(tag_name) +
-            "arg block tags.")
-        
+            "{0} template tag was supplied too many arg block tags.".format(
+                tag_name))
+
     macro.parser = parser
     return MacroBlockNode(macro, nodelist, args, kwargs)
 
@@ -341,6 +347,7 @@ class MacroArgNode(template.Node):
     """ Template node object for defining a
     positional argument to a MacroBlockNode.
     """
+
     def __init__(self, nodelist):
         # save the tag's contents
         self.nodelist = nodelist
@@ -372,6 +379,7 @@ class MacroKwargNode(MacroArgNode):
     """ Template node object for defining a
     keyword argument to a MacroBlockNode.
     """
+
     def __init__(self, keyword, nodelist):
         # save keyword so we know where to substitute it later.
         self.keyword = keyword
@@ -392,9 +400,9 @@ def do_macro_kwarg(parser, token):
     except ValueError:
         raise template.TemplateSyntaxError(
             "{0} tag requires exactly one argument, a keyword".format(
-            token.contents.split()[0]))
-    
+                token.contents.split()[0]))
+
     # add some validation of the keyword argument here.
-    nodelist = parser.parse(('endmacro_kwarg', ))
+    nodelist = parser.parse(('endmacro_kwarg',))
     parser.delete_first_token()
     return MacroKwargNode(keyword, nodelist)

--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -301,9 +301,7 @@ def do_macro_block(parser, token):
     # (we could do this more semantically, but we loop
     # only once like this as an optimization).
     for node in nodelist:
-        if isinstance(node, MacroArgNode):
-            args.append(node)
-        elif isinstance(node, MacroKwargNode):
+        if isinstance(node, MacroKwargNode):
             if node.keyword in macro.kwargs:
                 # check that the keyword is defined as an argument for
                 # the macro.
@@ -324,6 +322,10 @@ def do_macro_block(parser, token):
                     "{0} template tag was supplied with a "
                     "keyword argument not defined by the {1} macro.".format(
                         tag_name, macro_name))
+        elif isinstance(node, MacroArgNode):
+            # note that MacroKwargNode is also a MacroArgNode,
+            # so this must be under else/elif statement
+            args.append(node)
         elif not isinstance(node, template.TextNode) or node.s.strip() != "":
             # whitespace is allowed, anything else is not
             raise template.TemplateSyntaxError(


### PR DESCRIPTION
Hello,

First of all, thanks for a good library!

I wanted to use macros for common page components, and to my tastes `block_macro` syntax felt overly verbose for some use cases. So I've did a patch that allowed me to put short arguments in the tag declaration, while still fully enjoying all the `macro_arg`/`macro_kwarg` goodness for more arguments.

As an example, before this patch I had to write something like this:

```
{% macro_block modal  %}
    {% macro_arg %}mymodal{% endmacro_arg %}
    {% macro_arg %}
        <p>Here be dragons</p>
    {% endmacro_arg %}
    {% macro_kwarg title %}Modal dialog{% endmacro_kwarg %}
{% endmacro_block %}
```

The syntax extension allowed me to have this instead:

```
{% macro_block modal "mymodal" title="Modal dialog" %}
    {% macro_arg %}
        <p>Here be dragons.</p>
    {% endmacro_arg %}
{% endmacro_block %}
```

I've also did some refactoring, trying to eliminate nearly-duplicate code, reformatted `macros.py` to be more PEP8-compliant and implemented a check for extra content in `macro_block`, so there can't be anything besides argument tags and whitespace-only text nodes. Haven't touched any tests, though - sorry about this.

So... Here are my changes. Don't know if you'd like them or not, but offering those in hope they (or at least some of those commints) could be useful.

Thanks!
